### PR TITLE
Ignore new entry "FileDate" in the noga response

### DIFF
--- a/scripts/noga.py
+++ b/scripts/noga.py
@@ -42,7 +42,7 @@ def update(store, noga_type, start_date, end_date):
             date0 = entry.get("Date")
             date = date0.replace("/", "-")
             time = entry.get("Time")
-            for tag in [key for key in entry.keys() if key not in ["Date", "Time"]]:
+            for tag in [key for key in entry.keys() if key not in ["Date", "Time", "FileDate"]]:
                 values.append((namespace, date, time[0:5], tag, entry.get(tag)))
                 count = count + 1
                 total_count = total_count + 1


### PR DESCRIPTION
Noga apparently added a new field called "FileData" with values that are a list of dates, e.g.
DemandForecastModel>
<Date>03/06/2023</Date>
<FileDate>02/06/2023, 04/06/2023</FileDate>
<Renewable>0</Renewable>
<SystemDemand>9597</SystemDemand>
<Time>00:00:00</Time>
</DemandForecastModel>
Need to ignore this field.