### PR TITLE
ignore new entries in the api response, handle bad responses with non…

### DIFF
--- a/scripts/noga.py
+++ b/scripts/noga.py
@@ -1,5 +1,7 @@
 import json
 import logging
+import re
+
 import requests
 import os
 import datetime
@@ -42,8 +44,9 @@ def update(store, noga_type, start_date, end_date):
             date0 = entry.get("Date")
             date = date0.replace("/", "-")
             time = entry.get("Time")
-            for tag in [key for key in entry.keys() if key not in ["Date", "Time"]]:
-                values.append((namespace, date, time[0:5], tag, entry.get(tag)))
+            for tag in [key for key in entry.keys() if key not in ["Date", "Time", "FileDate", "IsOnBlobList"]]:
+                val = re.sub(r'[^0-9.]', '', str(entry.get(tag)).strip())
+                values.append((namespace, date, time[0:5], tag, val))
                 count = count + 1
                 total_count = total_count + 1
                 if count > 100:


### PR DESCRIPTION
The API response includes some new entries related to files
There is one response in SMP 25/2/23 that looks like this:

<SmpNewModel>
<ConstrainedSmp>98.84 </ConstrainedSmp>
<Date>25/02/2023</Date>
<FileLine>23</FileLine>
<FileName>prod/costs/SMP_tzahi.csv </FileName>
<IsOnBlobList>true</IsOnBlobList>
<IsSuccess>true</IsSuccess>
<Time>11:00:00</Time>
<UnconstrainedSmp>100.48wr </UnconstrainedSmp>
</SmpNewModel>

notice the "wr" in the numeric value